### PR TITLE
Part 2 follow up fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,15 +97,14 @@ RUN --mount=type=cache,sharing=private,target=/var/cache/apk \
     # macOS (Monterey), supports only Apple Silicon (aarch64/arm64)
     { \
         pkg_path="/opt/multiarch-libs/aarch64-apple-darwin"; \
-        mkdir -p $pkg_path/lib/pkgconfig; \
-        # run homebrew-downloader
         crystal run /homebrew-downloader.cr -- \
             $pkg_path \
             gmp \
             libevent \
             libgc \
+            libiconv \
             libyaml \
-            openssl \
+            openssl@3 \
             pcre2 \
             sqlite \
             zlib \
@@ -114,7 +113,7 @@ RUN --mount=type=cache,sharing=private,target=/var/cache/apk \
 
 # copy macOS dependencies back into `base`
 FROM base
-COPY --from=macos-packages --chmod=0444 /opt/multiarch-libs/aarch64-apple-darwin /opt/multiarch-libs/aarch64-apple-darwin
+COPY --from=macos-packages /opt/multiarch-libs/aarch64-apple-darwin /opt/multiarch-libs/aarch64-apple-darwin
 
 # install macOS SDK
 RUN --mount=type=cache,sharing=private,target=/var/cache/apk \

--- a/Dockerfile
+++ b/Dockerfile
@@ -129,7 +129,7 @@ RUN --mount=type=cache,sharing=private,target=/var/cache/apk \
         ; \
         wget -q -O sdk.tar.xz https://github.com/joseluisq/macosx-sdks/releases/download/${MACOS_SDK_VERSION}/MacOSX${MACOS_SDK_VERSION}.sdk.tar.xz; \
         echo "${MACOS_SDK_SHA256} *sdk.tar.xz" | sha256sum -c - >/dev/null 2>&1; \
-        tar -C /opt/multiarch-libs -xf sdk.tar.xz; \
+        tar -C /opt/multiarch-libs -xf sdk.tar.xz --no-same-owner; \
         rm sdk.tar.xz; \
         # symlink to latest version
         ln -nfs /opt/multiarch-libs/MacOSX${MACOS_SDK_VERSION}.sdk /opt/multiarch-libs/MacOSX${MACOS_SDK_MAJOR_VERSION}.sdk; \

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build: $(DOCKERFILE)
 
 .PHONY: run
 run: $(DOCKERFILE)
-	docker run -it --rm -v .:/app -w /app ${IMAGE_NAME}:${VERSION} sh -i
+	docker run -it --rm -u $$(id -u):$$(id -g) -v .:/app -w /app ${IMAGE_NAME}:${VERSION} sh -i
 
 .PHONY: ubuntu
 ubuntu:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can use the following one-liner to cross-compile an application and have
 the artifacts placed in the local `build/` directory:
 
 ```console
-$ docker run --rm -v $(pwd):/app -w /app crystal-xbuild:latest xbuild examples/hello.cr hello-mac aarch64-apple-darwin
+$ docker run --rm -u $(id -u):$(id -g) -v $(pwd):/app -w /app crystal-xbuild:latest xbuild examples/hello.cr hello-mac aarch64-apple-darwin
 Compiling 'build/aarch64-apple-darwin/hello-mac' ('examples/hello.cr')...
 Linking with: -lpcre2-8 -lgc -lpthread -levent -liconv
 Done.


### PR DESCRIPTION
Changes based on the discussion in Crystal Forums: https://forum.crystal-lang.org/t/cross-compiling-crystal-applications-part-2/7090

1. Corrects permission issues when running as non-root (also updates Makefile and README to show that)
2. Copies libiconv for macOS to workaround the issue reported in the thread
3. Updates `xbuild` to append `-Duse_libiconv` Crystal flag when targeting macOS
